### PR TITLE
Refine Codex setup script and documentation

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install only the tools that may be missing from the Codex workspace.
+if command -v apt-get >/dev/null 2>&1; then
+  export DEBIAN_FRONTEND=noninteractive
+
+  apt_cache_updated=0
+  packages=()
+
+  if ! command -v python3 >/dev/null 2>&1; then
+    packages+=(python3 python3-pip)
+  elif ! python3 -m pip --version >/dev/null 2>&1; then
+    packages+=(python3-pip)
+  fi
+
+  for pkg in ca-certificates curl gnupg; do
+    if ! dpkg -s "$pkg" >/dev/null 2>&1; then
+      packages+=("$pkg")
+    fi
+  done
+
+  if ! command -v lsb_release >/dev/null 2>&1; then
+    packages+=(lsb-release)
+  fi
+
+  if ((${#packages[@]})); then
+    apt-get update
+    apt_cache_updated=1
+    apt-get install -y --no-install-recommends "${packages[@]}"
+  fi
+
+  if ! command -v terraform >/dev/null 2>&1; then
+    install -d -m 0755 /etc/apt/keyrings
+    if [[ ! -f /etc/apt/keyrings/hashicorp-archive-keyring.gpg ]]; then
+      curl -fsSL https://apt.releases.hashicorp.com/gpg \
+        | gpg --dearmor -o /etc/apt/keyrings/hashicorp-archive-keyring.gpg
+    fi
+    echo "deb [signed-by=/etc/apt/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" \
+      | tee /etc/apt/sources.list.d/hashicorp.list >/dev/null
+    apt-get update
+    apt_cache_updated=1
+    apt-get install -y --no-install-recommends terraform
+  fi
+
+  if [[ "$apt_cache_updated" == 1 ]]; then
+    rm -rf /var/lib/apt/lists/*
+  fi
+fi
+
+# Install Python dependencies.
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+python3 -m pip install --upgrade pip
+python3 -m pip install -r "${PROJECT_ROOT}/requirements.txt"

--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ docker build -t gcr.io/PROJECT_ID/gcp-cost-notifier:latest .
 docker push gcr.io/PROJECT_ID/gcp-cost-notifier:latest
 ```
 
+### Codex 用セットアップ
+
+`.codex/setup.sh` が Codex の作業環境で行う処理や追加インストールの詳細は、[Codex コーディング環境セットアップガイド](docs/codex_setup.md) を参照してください。
+
 ### Terraform の初期設定
 
 1. `terraform/credentials.tf.example` を `terraform/credentials.tf` にコピーし、

--- a/docs/codex_setup.md
+++ b/docs/codex_setup.md
@@ -1,0 +1,46 @@
+# Codex コーディング環境セットアップガイド
+
+このドキュメントでは、OpenAI Codex による自動コーディングを行う際に `.codex/setup.sh` がどのような環境準備を行うかを説明します。
+ローカル開発者向けのセットアップではなく、Codex のワークスペースで不足しがちなツールのみを補うことを目的としています。
+
+## 方針
+
+- Codex が標準で用意しているツール (Python や pip など) を再インストールすることはありません。
+- Terraform など、Codex 環境に含まれない可能性が高いツールだけを追加します。
+- Python の依存関係は `requirements.txt` を元に毎回同期し、スクリプト実行直後からテストを行えるようにします。
+
+## 実行手順
+
+Codex がタスクを開始すると自動的に `.codex/setup.sh` を実行します。手動で確認したい場合は、リポジトリのルートで次のコマンドを実行してください。
+
+```bash
+cd /path/to/GC-price-checker
+./.codex/setup.sh
+```
+
+## スクリプトの処理内容
+
+`.codex/setup.sh` は以下の順序で処理を行います。
+
+1. `apt-get` が利用できる場合に限り、Codex 環境に存在しない可能性があるシステムパッケージを確認します。
+   不足しているものだけを追加インストールします。
+   - `ca-certificates`
+   - `curl`
+   - `gnupg`
+   - `lsb-release`
+   - `python3`
+   - `python3-pip`
+2. Terraform がインストールされていない場合は、HashiCorp の公式リポジトリを追加して Terraform を導入します。
+3. `pip` を最新化し、`requirements.txt` に記載された依存関係をインストールします。
+
+## トラブルシューティング
+
+- Codex 以外の環境でスクリプトを実行する場合、`apt-get` が利用できるか確認してください。
+- プロキシ経由での通信が必要な場合は、`curl` が外部サイトへアクセスできるよう環境変数を設定してから再実行してください。
+- Terraform を独自に管理している環境では、スクリプトが新しいリポジトリを追加する点に注意してください。
+
+## 参考情報
+
+- Terraform: <https://developer.hashicorp.com/terraform>
+- Cloud Run: <https://cloud.google.com/run>
+- Cloud Scheduler: <https://cloud.google.com/scheduler>


### PR DESCRIPTION
## Summary
- update `.codex/setup.sh` to install only missing system tools in the Codex workspace and to guard Terraform setup with prerequisite checks
- replace the local setup document with a Codex-focused guide and update the README link accordingly

## Testing
- bash -n .codex/setup.sh

------
https://chatgpt.com/codex/tasks/task_e_68cfae7d99c0833094c0bf1eb679e182